### PR TITLE
Introduce implicit `HtmlArmor` handling

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,7 +8,7 @@ if ( defined( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONUSERINTERFACE_VERSION' ) ) {
 	return;
 }
 
-define( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONUSERINTERFACE_VERSION', '3.0.3' );
+define( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONUSERINTERFACE_VERSION', '3.0.4' );
 
 MWStake\MediaWiki\ComponentLoader\Bootstrapper::getInstance()
 ->register( 'commonuserinterface', function () {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	},
 	"devDependencies": {
 		"eslint-config-wikimedia": "0.15.0",
-		"grunt": "1.4.0",
+		"grunt": "1.5.3",
 		"grunt-banana-checker": "0.8.1",
 		"grunt-eslint": "22.0.0"
 	}

--- a/src/LinkFormatter.php
+++ b/src/LinkFormatter.php
@@ -2,6 +2,7 @@
 
 namespace MWStake\MediaWiki\Component\CommonUserInterface;
 
+use HtmlArmor;
 use Linker;
 use Message;
 
@@ -65,6 +66,7 @@ class LinkFormatter {
 			} else {
 				continue;
 			}
+			//$link['text'] = HtmlArmor::getHtml( $link['text'] );
 
 			if ( isset( $link['title'] ) && $link['title'] !== '' ) {
 				$msg = Message::newFromKey( $link['title'] );

--- a/src/LinkFormatter.php
+++ b/src/LinkFormatter.php
@@ -2,7 +2,6 @@
 
 namespace MWStake\MediaWiki\Component\CommonUserInterface;
 
-use HtmlArmor;
 use Linker;
 use Message;
 
@@ -66,7 +65,6 @@ class LinkFormatter {
 			} else {
 				continue;
 			}
-			//$link['text'] = HtmlArmor::getHtml( $link['text'] );
 
 			if ( isset( $link['title'] ) && $link['title'] !== '' ) {
 				$msg = Message::newFromKey( $link['title'] );

--- a/src/Renderer/Accordion.php
+++ b/src/Renderer/Accordion.php
@@ -39,4 +39,11 @@ class Accordion extends RendererBase {
 		return $this->templateBasePath . '/accordion.mustache';
 	}
 
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'header-text', 'body' ];
+	}
+
 }

--- a/src/Renderer/Card.php
+++ b/src/Renderer/Card.php
@@ -43,4 +43,10 @@ class Card extends RendererBase {
 		return $templateData;
 	}
 
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/CardBody.php
+++ b/src/Renderer/CardBody.php
@@ -48,4 +48,11 @@ class CardBody extends RendererBase {
 
 		return $templateData;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/CardFooter.php
+++ b/src/Renderer/CardFooter.php
@@ -48,4 +48,11 @@ class CardFooter extends RendererBase {
 
 		return $templateData;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/CardHeader.php
+++ b/src/Renderer/CardHeader.php
@@ -48,4 +48,11 @@ class CardHeader extends RendererBase {
 
 		return $templateData;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/CardLink.php
+++ b/src/Renderer/CardLink.php
@@ -67,4 +67,13 @@ class CardLink extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/card-link.mustache';
 	}
+
+	/**
+	 * `AriaAttributesBuilder` and `DataAttributesBuilder` are already using
+	 * `Sanitizer::safeEncodeTagAttributes`
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body', 'data' ];
+	}
 }

--- a/src/Renderer/CardSubTitle.php
+++ b/src/Renderer/CardSubTitle.php
@@ -48,4 +48,11 @@ class CardSubTitle extends RendererBase {
 
 		return $templateData;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/CardText.php
+++ b/src/Renderer/CardText.php
@@ -48,4 +48,11 @@ class CardText extends RendererBase {
 
 		return $templateData;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/CardTitle.php
+++ b/src/Renderer/CardTitle.php
@@ -48,4 +48,11 @@ class CardTitle extends RendererBase {
 
 		return $templateData;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/Dropdown.php
+++ b/src/Renderer/Dropdown.php
@@ -76,4 +76,11 @@ class Dropdown extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/dropdown.mustache';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/DropdownButton.php
+++ b/src/Renderer/DropdownButton.php
@@ -84,4 +84,11 @@ class DropdownButton extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/dropdown-button.mustache';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/DropdownIcon.php
+++ b/src/Renderer/DropdownIcon.php
@@ -84,4 +84,11 @@ class DropdownIcon extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/dropdown-icon.mustache';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/DropdownIconSplitButton.php
+++ b/src/Renderer/DropdownIconSplitButton.php
@@ -118,4 +118,11 @@ class DropdownIconSplitButton extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/dropdown-icon-split-button.mustache';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/DropdownItemlist.php
+++ b/src/Renderer/DropdownItemlist.php
@@ -56,4 +56,11 @@ class DropdownItemlist extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/dropdown-itemlist.mustache';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/DropdownItemlistFromArray.php
+++ b/src/Renderer/DropdownItemlistFromArray.php
@@ -76,4 +76,13 @@ class DropdownItemlistFromArray extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/dropdown-itemlist-from-array.mustache';
 	}
+
+	/**
+	 * `AriaAttributesBuilder` and `DataAttributesBuilder` are already using
+	 * `Sanitizer::safeEncodeTagAttributes`
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'aria', 'body', 'data' ];
+	}
 }

--- a/src/Renderer/DropdownItemlistItem.php
+++ b/src/Renderer/DropdownItemlistItem.php
@@ -56,4 +56,11 @@ class DropdownItemlistItem extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/dropdown-itemlist-item.mustache';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/DropdownSplitButton.php
+++ b/src/Renderer/DropdownSplitButton.php
@@ -110,4 +110,11 @@ class DropdownSplitButton extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/dropdown-split-button.mustache';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/DropdownSplitLink.php
+++ b/src/Renderer/DropdownSplitLink.php
@@ -111,4 +111,11 @@ class DropdownSplitLink extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/dropdown-split-link.mustache';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/Link.php
+++ b/src/Renderer/Link.php
@@ -119,4 +119,13 @@ class Link extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/link.mustache';
 	}
+
+	/**
+	 * `AriaAttributesBuilder` and `DataAttributesBuilder` are already using
+	 * `Sanitizer::safeEncodeTagAttributes`
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'aria', 'data' ];
+	}
 }

--- a/src/Renderer/LinklistGroupFromArray.php
+++ b/src/Renderer/LinklistGroupFromArray.php
@@ -3,7 +3,6 @@
 namespace MWStake\MediaWiki\Component\CommonUserInterface\Renderer;
 
 use Exception;
-use HtmlArmor;
 use MWStake\MediaWiki\Component\CommonUserInterface\AriaAttributesBuilder;
 use MWStake\MediaWiki\Component\CommonUserInterface\DataAttributesBuilder;
 use MWStake\MediaWiki\Component\CommonUserInterface\IComponent;

--- a/src/Renderer/LinklistGroupFromArray.php
+++ b/src/Renderer/LinklistGroupFromArray.php
@@ -3,6 +3,7 @@
 namespace MWStake\MediaWiki\Component\CommonUserInterface\Renderer;
 
 use Exception;
+use HtmlArmor;
 use MWStake\MediaWiki\Component\CommonUserInterface\AriaAttributesBuilder;
 use MWStake\MediaWiki\Component\CommonUserInterface\DataAttributesBuilder;
 use MWStake\MediaWiki\Component\CommonUserInterface\IComponent;
@@ -86,5 +87,14 @@ class LinklistGroupFromArray extends RendererBase {
 	 */
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/linklist-group-from-array.mustache';
+	}
+
+	/**
+	 * `AriaAttributesBuilder` and `DataAttributesBuilder` are already using
+	 * `Sanitizer::safeEncodeTagAttributes`
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'aria', 'data' ];
 	}
 }

--- a/src/Renderer/Literal.php
+++ b/src/Renderer/Literal.php
@@ -51,4 +51,11 @@ class Literal extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/literal.mustache';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
 }

--- a/src/Renderer/MediaObject.php
+++ b/src/Renderer/MediaObject.php
@@ -66,4 +66,11 @@ class MediaObject extends RendererBase {
 		return $templateData;
 	}
 
+	/**
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'body' ];
+	}
+
 }

--- a/src/Renderer/RendererBase.php
+++ b/src/Renderer/RendererBase.php
@@ -2,6 +2,7 @@
 
 namespace MWStake\MediaWiki\Component\CommonUserInterface\Renderer;
 
+use HtmlArmor;
 use MWStake\MediaWiki\Component\CommonUserInterface\IComponentRenderer;
 use TemplateParser;
 
@@ -35,6 +36,7 @@ abstract class RendererBase implements IComponentRenderer {
 		// TODO: Maybe add a "getTemplateFileExtension" method to the interface?
 		$templateFilename = preg_replace( '#\.mustache$#', '', $templateFilename );
 		$this->templateParser = new TemplateParser( $templateDirname );
+		$data = $this->preprocessData( $data );
 		$html = $this->templateParser->processTemplate( $templateFilename, $data );
 		// An empty string causes an
 		//  PHP Notice: 'Array to string conversion inincludes/TemplateParser.php(173) : eval()'d'
@@ -43,6 +45,32 @@ abstract class RendererBase implements IComponentRenderer {
 			$html = "\0";
 		}
 		return $html;
+	}
+
+	protected function preprocessData( $data ) {
+		$htmlArmorExcludedFieldNames = $this->getHtmlArmorExcludedFields();
+		$processedData = [];
+		foreach( $data as $fieldName => $dataValue ) {
+			if ( is_array( $dataValue ) ) {
+				foreach ( $dataValue as $subDataKey => $subDataValue ) {
+					$dataValue[$subDataKey] = $this->preprocessData( $subDataValue );
+				}
+			}
+			else if ( !in_array( $fieldName, $htmlArmorExcludedFieldNames ) ) {
+				$dataValue = HtmlArmor::getHtml( $dataValue );
+			}
+			$processedData[$fieldName] = $dataValue;
+		}
+
+		return $processedData;
+	}
+
+	/**
+	 * Explicitly list field names that should not be automatically handeled with `HtmlArmor`
+	 * @return string[]
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [];
 	}
 
 	/**

--- a/src/Renderer/RendererBase.php
+++ b/src/Renderer/RendererBase.php
@@ -47,16 +47,20 @@ abstract class RendererBase implements IComponentRenderer {
 		return $html;
 	}
 
+	/**
+	 * Handle `HtmlArmor`
+	 * @param array $data
+	 * @return array
+	 */
 	protected function preprocessData( $data ) {
 		$htmlArmorExcludedFieldNames = $this->getHtmlArmorExcludedFields();
 		$processedData = [];
-		foreach( $data as $fieldName => $dataValue ) {
+		foreach ( $data as $fieldName => $dataValue ) {
 			if ( is_array( $dataValue ) ) {
 				foreach ( $dataValue as $subDataKey => $subDataValue ) {
 					$dataValue[$subDataKey] = $this->preprocessData( $subDataValue );
 				}
-			}
-			else if ( !in_array( $fieldName, $htmlArmorExcludedFieldNames ) ) {
+			} elseif ( !in_array( $fieldName, $htmlArmorExcludedFieldNames ) ) {
 				$dataValue = HtmlArmor::getHtml( $dataValue );
 			}
 			$processedData[$fieldName] = $dataValue;

--- a/src/Renderer/TextLink.php
+++ b/src/Renderer/TextLink.php
@@ -116,4 +116,13 @@ class TextLink extends RendererBase {
 	public function getTemplatePathname() : string {
 		return $this->templateBasePath . '/link.mustache';
 	}
+
+	/**
+	 * `AriaAttributesBuilder` and `DataAttributesBuilder` are already using
+	 * `Sanitizer::safeEncodeTagAttributes`
+	 * @inheritDoc
+	 */
+	protected function getHtmlArmorExcludedFields() {
+		return [ 'aria', 'data' ];
+	}
 }


### PR DESCRIPTION
Require sub-classes of `RendererBase` to explicitly declare exceptions.
    
ERM29427
ERM29429
ERM29430
