### PR TITLE
Fix escaped/encoded labels in tree nodes

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,7 +8,7 @@ if ( defined( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONUSERINTERFACE_VERSION' ) ) {
 	return;
 }
 
-define( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONUSERINTERFACE_VERSION', '3.2.2' );
+define( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONUSERINTERFACE_VERSION', '3.2.3' );
 
 MWStake\MediaWiki\ComponentLoader\Bootstrapper::getInstance()
 ->register( 'commonuserinterface', function () {

--- a/resources/templates/tree-link-node.mustache
+++ b/resources/templates/tree-link-node.mustache
@@ -1,6 +1,6 @@
 <li{{#id}} id="{{.}}"{{/id}} class="mws-tree-item{{class}}" {{#role}} role="{{.}}"{{/role}}>
 	<div>
-		{{#expandBtn}}<a class="mws-tree-expander{{class}}" aria-expanded="{{expanded}}" role="button" tabindex="0" aria-label="{{text}}"{{#id}} aria-controlls="{{.}}-children"{{/id}}{{#hasChildren}} aria-haspopup="true"{{/hasChildren}}></a>{{/expandBtn}}<a id="{{labelId}}" class="mws-tree-item-label{{#isNew}} new{{/isNew}}" href="{{href}}"{{#title}} title="{{{.}}}"{{/title}}{{#rel}} rel="{{{.}}}"{{/rel}}{{#target}} target="{{{.}}}"{{/target}}>{{text}}</a>
+		{{#expandBtn}}<a class="mws-tree-expander{{class}}" aria-expanded="{{expanded}}" role="button" tabindex="0" aria-label="{{text}}"{{#id}} aria-controlls="{{.}}-children"{{/id}}{{#hasChildren}} aria-haspopup="true"{{/hasChildren}}></a>{{/expandBtn}}<a id="{{labelId}}" class="mws-tree-item-label{{#isNew}} new{{/isNew}}" href="{{href}}"{{#title}} title="{{{.}}}"{{/title}}{{#rel}} rel="{{{.}}}"{{/rel}}{{#target}} target="{{{.}}}"{{/target}}>{{{text}}}</a>
 	</div>
 	{{#hasChildren}}
 	<div class="mws-tree-cnt{{#expanded}} show{{/expanded}}" role="tree" aria-labelledby="{{labelId}}" aria-expanded="expanded" tabindex="0">


### PR DESCRIPTION
Since all variables are HTML escaped by default, texts vars need to be wrapped in three curly braces

[4.3.1]

ERM33161