### PR TITLE
Add convenience method for mixed types

### DIFF
--- a/src/Component/RestrictedTextLink.php
+++ b/src/Component/RestrictedTextLink.php
@@ -109,4 +109,12 @@ class RestrictedTextLink extends ComponentBase implements ITextLink, IRestricted
 	public function getPermissions(): array {
 		return $this->options['permissions'];
 	}
+
+	/**
+	 * @param string|Message $stringOrMessage
+	 * @return Message
+	 */
+	protected function ensureMessageObject( $stringOrMessage ) {
+		return $stringOrMessage instanceof Message ? $stringOrMessage : new RawMessage( $stringOrMessage );
+	}
 }

--- a/src/DataAttributesBuilder.php
+++ b/src/DataAttributesBuilder.php
@@ -20,6 +20,9 @@ class DataAttributesBuilder {
 		$attribs = [];
 
 		foreach ( $data  as $key => $value ) {
+			if ( $value === null ) {
+				$value = 'null';
+			}
 			$attrib = Sanitizer::safeEncodeTagAttributes( [
 				"data-$key" => $value
 			] );


### PR DESCRIPTION
This eases usage of methods with mixed return value types, like `SpecialPage::getDescription : string|Message`

ERM38444