### PR TITLE
Support Message objects

### DIFF
--- a/src/AriaAttributesBuilder.php
+++ b/src/AriaAttributesBuilder.php
@@ -2,6 +2,7 @@
 
 namespace MWStake\MediaWiki\Component\CommonUserInterface;
 
+use MediaWiki\Message\Message;
 use MediaWiki\Parser\Sanitizer;
 
 class AriaAttributesBuilder {
@@ -24,6 +25,11 @@ class AriaAttributesBuilder {
 			if ( $value === '' ) {
 				continue;
 			}
+
+			if ( $value instanceof Message ) {
+				$value = $value->text();
+			}
+
 			$attrib = Sanitizer::safeEncodeTagAttributes( [
 				"aria-$key" => $value
 			] );


### PR DESCRIPTION
Fixes: Argument #1 ($text) must be of type string, MediaWiki\Message\Message given, called in /app/bluespice/w/includes/Parser/Sanitizer.php

ERM48314

[5.1.x]